### PR TITLE
SC-8434 - Adds ccm:replicationsourceuuid to mds_oeh_override.xml

### DIFF
--- a/schulcloud/docker-compose-dev.yml
+++ b/schulcloud/docker-compose-dev.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+services:
+
+  edusharing:
+#    image: edusharing/repo-rs-moodle:sc-latest
+    build: .
+    container_name: edusharing_docker
+    ports:
+      - "8080:80"
+    volumes:
+      - "alf_data:/usr/local/alfresco/alf_data/"
+      - "pg_data:/pg_data/"
+      - "moodle_data:/var/moodledata/"
+      - "rs_cache:/var/cache/esrender/"
+      - "mds_xml_dir:/usr/local/tomcat/shared/classes/org/edu_sharing/metadataset/v2/xml"
+    environment:
+      - "PORT=80"
+      - "DOMAIN=content.schul-cloud.dev"
+      - "SCHEME=https"
+    # network_mode: host
+    deploy:  # For Docker Swarm.
+      restart_policy:
+        condition: on-failure
+
+volumes:
+  alf_data:
+  pg_data:
+  moodle_data:
+  rs_cache:
+  mds_xml_dir:

--- a/schulcloud/metadatasets/mds_oeh_override.xml
+++ b/schulcloud/metadatasets/mds_oeh_override.xml
@@ -24,6 +24,11 @@
 				<multiplejoin>OR</multiplejoin>
 			</property>
 
+			<property name="ccm:replicationsourceuuid">
+				<multiple>true</multiple>
+				<multiplejoin>OR</multiplejoin>
+			</property>
+
 		</query>
 	</queries>
 	<queries syntax="dsl">
@@ -44,6 +49,11 @@
 			</property>
 
 			<property name="ccm:hpi_lom_relation">
+				<multiple>true</multiple>
+				<multiplejoin>OR</multiplejoin>
+			</property>
+
+			<property name="ccm:replicationsourceuuid">
 				<multiple>true</multiple>
 				<multiplejoin>OR</multiplejoin>
 			</property>


### PR DESCRIPTION
# Description
Provides querying capabilities using ccm:replicationsourceuuid. Additionally, adds a dedicated docker-compose-dev.yml file with the docker-compose config for our .dev machine.
## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8434
## Changes
## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
## Deployment
## New Repos, NPM pakages or vendor scripts
## Screenshots of UI changes
## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
