### PR TITLE
BC-8629 - Activate h5p-content “MedienLB” for NBC via Lernstore

### DIFF
--- a/schulcloud/h5p/metadata.py
+++ b/schulcloud/h5p/metadata.py
@@ -87,14 +87,10 @@ class MetadataFile:
             permissions = []
             for row in range(1, sheet.max_row + 1):
                 permissions_raw = sheet.cell(row=row, column=self.COLUMN.PERMISSION).value
-                permissions.append(permissions_raw)
-            first_permission = permissions[0]
+                permissions = permissions + [permission.strip() for permission in permissions_raw.split(',')]
             for permission in permissions:
                 if permission not in ('NDS', 'BRB', 'THR', 'ALLE'):
                     raise ParsingError(f'Spelling mistake or unknown permission: {permission} at {self._file.name}')
-                elif permission != first_permission:
-                    raise ParsingError(f'Permissions in the collection: "{collection}" of "{self._file.name}" '
-                                       f'are not matching! ({first_permission} != {permission})')
 
     def _parse(self):
         """

--- a/schulcloud/h5p/metadata.py
+++ b/schulcloud/h5p/metadata.py
@@ -86,8 +86,7 @@ class MetadataFile:
             # Check permissions of collection
             permissions = []
             for row in range(1, sheet.max_row + 1):
-                permissions_raw = sheet.cell(row=row, column=self.COLUMN.PERMISSION).value
-                permissions += re.findall(r'\w+', permissions_raw)
+                permissions += re.findall(r'\w+', sheet.cell(row=row, column=self.COLUMN.PERMISSION).value)
             for permission in permissions:
                 if permission not in ('NDS', 'BRB', 'THR', 'ALLE'):
                     raise ParsingError(f'Spelling mistake or unknown permission: {permission} at {self._file.name}')

--- a/schulcloud/h5p/metadata.py
+++ b/schulcloud/h5p/metadata.py
@@ -87,7 +87,7 @@ class MetadataFile:
             permissions = []
             for row in range(1, sheet.max_row + 1):
                 permissions_raw = sheet.cell(row=row, column=self.COLUMN.PERMISSION).value
-                permissions = permissions + [permission.strip() for permission in permissions_raw.split(',')]
+                permissions += re.findall(r'\w+', permissions_raw)
             for permission in permissions:
                 if permission not in ('NDS', 'BRB', 'THR', 'ALLE'):
                     raise ParsingError(f'Spelling mistake or unknown permission: {permission} at {self._file.name}')

--- a/schulcloud/h5p/upload.py
+++ b/schulcloud/h5p/upload.py
@@ -172,7 +172,7 @@ class Uploader:
         @param permissions: List of known permissions
         """
         if 'ALLE' in permissions:
-            return List(GROUPS_EXCEL_TO_ES.values())
+            return list(GROUPS_EXCEL_TO_ES.values())
         else:
             groups = [group.strip() for group in permissions.split(',')]
             return [GROUPS_EXCEL_TO_ES[group] for group in groups]

--- a/schulcloud/h5p/upload.py
+++ b/schulcloud/h5p/upload.py
@@ -171,10 +171,12 @@ class Uploader:
         Return permitted groups from Excelsheet, which matching with the list.
         @param permissions: List of known permissions
         """
+        print("Permissions: ", permissions)
         if 'ALLE' in permissions:
-            return list(GROUPS_EXCEL_TO_ES.values())
+            return List(GROUPS_EXCEL_TO_ES.values())
         else:
-            return [GROUPS_EXCEL_TO_ES[group] for group in permissions]
+            groups = [group.strip() for group in permissions.split(',')]
+            return [GROUPS_EXCEL_TO_ES[group] for group in groups]
 
     def collection_status(self, collection: Collection, collection_node: Node):
         """

--- a/schulcloud/h5p/upload.py
+++ b/schulcloud/h5p/upload.py
@@ -174,8 +174,7 @@ class Uploader:
         if 'ALLE' in permissions:
             return list(GROUPS_EXCEL_TO_ES.values())
         else:
-            permission_list = [permission.strip() for permission in permissions[0].split(',')]
-            return [GROUPS_EXCEL_TO_ES[group] for group in permission_list]
+            return [GROUPS_EXCEL_TO_ES[group] for group in permissions]
 
     def collection_status(self, collection: Collection, collection_node: Node):
         """

--- a/schulcloud/h5p/upload.py
+++ b/schulcloud/h5p/upload.py
@@ -174,8 +174,8 @@ class Uploader:
         if 'ALLE' in permissions:
             return list(GROUPS_EXCEL_TO_ES.values())
         else:
-            groups = [group.strip() for group in permissions.split(',')]
-            return [GROUPS_EXCEL_TO_ES[group] for group in groups]
+            permission_list = [permission.strip() for permission in permissions[0].split(',')]
+            return [GROUPS_EXCEL_TO_ES[group] for group in permission_list]
 
     def collection_status(self, collection: Collection, collection_node: Node):
         """

--- a/schulcloud/h5p/upload.py
+++ b/schulcloud/h5p/upload.py
@@ -171,7 +171,6 @@ class Uploader:
         Return permitted groups from Excelsheet, which matching with the list.
         @param permissions: List of known permissions
         """
-        print("Permissions: ", permissions)
         if 'ALLE' in permissions:
             return List(GROUPS_EXCEL_TO_ES.values())
         else:


### PR DESCRIPTION
# Description

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->
Like Thuringia, Lower Saxony has bought h5p content from the provider MedienLB. This content is to be made available to users via the learnstore NBC.

The H5P Edu-sharing Spider is written at python and reade an Excel file to get the Metadata set for an h5p content what is stored at an s3.
The Excel file has one line for each h5p content, this line has the Metadata and also the country for this file.
Bad ist if an H5P Content line is double with the same name and Metadata but the County is the same the H5P Spider would overwrite the old ones.
The reason for it is that the H5P Content aka File and Metadata in Both lines are mapped to the same hash at edu-sharing that result in best case in overwriting the old ones and at worst case the h5p spider crash and that it's.

To solve this the source code for the h5p spider must be extend to handle on country or an comma separated list of countries to set the Permission for an h5p Content at edu-sharing.

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
JIRA :
- https://ticketsystem.dbildungscloud.de/browse/BC-8629

Related PRs :
- https://github.com/hpi-schul-cloud/infra-deploy/pull/48

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
